### PR TITLE
Reduce Docker image size with multi-stage build

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -34,7 +34,10 @@ def main(ctx):
         publish_step(
           "publish-branch",
           [ctx.build.branch],
-          {"event": ["push"]}
+          {
+            "event": ["push"],
+            "repo": "mishajw/kipa",
+          },
         ),
         publish_step(
           "publish-tag",

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,7 @@ RUN \
   apt-get update && \
   apt-get -y install \
     clang make automake libc-dev libclang-dev pkg-config curl gnupg protobuf-compiler \
-    libgmp-dev nettle-dev && \
-    apt-get clean
+    libgmp-dev nettle-dev
 
 WORKDIR /root/kipa
 COPY Cargo.lock Cargo.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM rust:slim-buster
 
 RUN \
   apt-get update && \
-  apt-get -y install \
+  apt-get -y install --no-install-recommends \
     clang make automake libc-dev libclang-dev pkg-config curl gnupg protobuf-compiler \
     libgmp-dev nettle-dev
 

--- a/resources/docker-run.sh
+++ b/resources/docker-run.sh
@@ -4,8 +4,8 @@
 
 set -e
 
-KEY_FILE="/root/key"
-KEY_PASSWORD_FILE="/root/key-password"
+KEY_FILE="${KEY_FILE:-/root/key}"
+KEY_PASSWORD_FILE="${KEY_PASSWORD_FILE:-/root/key-password}"
 
 if ! [ -e "$KEY_FILE" ]; then
   echo "$KEY_FILE not mounted."
@@ -17,9 +17,9 @@ if ! [ -e "$KEY_PASSWORD_FILE" ]; then
 fi
 
 # Import the secret key + all keys in `./resources/keys`.
-gpg --import --batch /root/key
+gpg --import --batch "$KEY_FILE"
 gpg --import --batch ./resources/keys/*.asc
 kipa-daemon \
   -vvvv \
-  --secret-path /root/key-password \
+  --secret-path "$KEY_PASSWORD_FILE" \
   "$@"


### PR DESCRIPTION
Current head image is almost 2G (!?!)
```
$ docker images mishajw/kipa                          
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
mishajw/kipa        latest              4a5a84783d02        25 hours ago        1.91GB
```

With this change, disk freedom!
```
$ docker build --pull -t mishajw/kipa:slim .                                         
Sending build context to Docker daemon  1.877MB
Step 1/15 : FROM rust:slim-buster
...
Successfully built e00307e37313
Successfully tagged mishajw/kipa:slim

$ docker images mishajw/kipa:slim                                    
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
mishajw/kipa        slim                e00307e37313        2 minutes ago       96.1MB
```

I haven't tested kipa functionality but at least all dynamically linked libraries (and gnupg) are present in the resulting image.

This fixes #15 